### PR TITLE
Exporting GPS accuracy as a comment. Fixes #6.

### DIFF
--- a/bin/gopro2gpx/gopro2gpx.go
+++ b/bin/gopro2gpx/gopro2gpx.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"time"
+	"strconv"
 
 	"github.com/JuanIrache/gopro-utils/telemetry"
 	"github.com/mlouielu/gpxgo/gpx"
@@ -69,6 +70,7 @@ func main() {
 						Elevation: *gpx.NewNullableFloat64(telems[i].Altitude),
 					},
 					Timestamp: time.Unix(telems[i].TS/1000/1000, telems[i].TS%(1000*1000)*1000).UTC(),
+					Comment: "GpsAccuracy: " + strconv.Itoa(int(telems[i].GpsAccuracy)),
 				},
 			)
 		}


### PR DESCRIPTION
Generates:

```xml
			<trkpt lat="50.2270925" lon="8.678743">
				<ele>214.416</ele>
				<time>2018-09-29T08:07:30.179Z</time>
				<cmt>GpsAccuracy: 200</cmt>
			</trkpt>
```