### PR TITLE
Added a delimiter `; ` between GpsAccuracy and GpsFix in the cmt

### DIFF
--- a/bin/gopro2gpx/gopro2gpx.go
+++ b/bin/gopro2gpx/gopro2gpx.go
@@ -72,7 +72,7 @@ func main() {
 						Elevation: *gpx.NewNullableFloat64(telems[i].Altitude),
 					},
 					Timestamp: time.Unix(telems[i].TS/1000/1000, telems[i].TS%(1000*1000)*1000).UTC(),
-					Comment: "GpsAccuracy: " + strconv.Itoa(int(t_prev.GpsAccuracy.Accuracy)) + "GpsFix: " + strconv.Itoa(int(t_prev.GpsFix.F)),
+					Comment: "GpsAccuracy: " + strconv.Itoa(int(t_prev.GpsAccuracy.Accuracy)) + "; GpsFix: " + strconv.Itoa(int(t_prev.GpsFix.F)),
 				},
 			)
 		}


### PR DESCRIPTION
Fixes JuanIrache/gopro-utils#8.